### PR TITLE
Don't add error code to JSON array in REST mode

### DIFF
--- a/src/programy/clients/rest.py
+++ b/src/programy/clients/rest.py
@@ -98,7 +98,7 @@ def ask():
                     "error": str(excep)
                    }
 
-        return jsonify({'response': response}, 400)
+        return jsonify({'response': response})
 
 if __name__ == '__main__':
 


### PR DESCRIPTION
```
root@archi:~# curl 'http://127.0.0.1:5000/api/v1.0/ask?sessionid=1&question=hello'
{
  "response": {
    "answer": "Hi nice to see you!",
    "question": "hello",
    "sessionid": "1"
  }
}
```

```
root@archi:~# curl 'http://127.0.0.1:5000/api/v1.0/ask?sessionid=1&question=no%20one%20has%20a%20reply%20to%20toaster'
[
  {
    "response": {
      "answer": "Sorry, I don't have an answer for that!",
      "error": "maximum recursion depth exceeded",
      "question": "no one has a reply to toaster",
      "sessionid": "1"
    }
  },
  400
]
```

If we absolutely want to include some kind of error-code, it should be in JSON array itself, perhaps together with non-200 response. Including "400" in JSON array doesn't make any sense, since we have error property already for checking if AIML call succeeded, and even if it didn't, request in fact did succeed regardless, so that 400 there is ambiguous in my opinion.

If we want to return HTTP error code to the caller, it should be done in HTTP response itself, and not in JSON as part of JSON array. It makes parsing a lot more problematic if we get 200 OK with random JSON array with "400" inside.