### PR TITLE
Fix REST client

### DIFF
--- a/src/programy/clients/rest.py
+++ b/src/programy/clients/rest.py
@@ -17,7 +17,7 @@ import logging
 from flask import Flask, jsonify, request, make_response, abort
 
 from programy.clients.clients import BotClient
-from programy.config.config import RestClientConfiguration
+from programy.config.client.rest import RestClientConfiguration
 
 class RestBotClient(BotClient):
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "../../src/programy/clients/rest.py", line 20, in <module>
    from programy.config.config import RestClientConfiguration
ImportError: No module named 'programy.config.config'
```