### PR TITLE
Ignore case for denormalization

### DIFF
--- a/src/programy/mappings/base.py
+++ b/src/programy/mappings/base.py
@@ -177,7 +177,7 @@ class DoubleStringPatternSplitCollection(BaseCollection):
         alreadys = []
         for pair in self.pairs:
             try:
-                pattern = re.compile(pair[1])
+                pattern = re.compile(pair[1],re.IGNORECASE)
                 if pattern.findall(replacable):
                     found = False
                     for already in alreadys:
@@ -185,7 +185,7 @@ class DoubleStringPatternSplitCollection(BaseCollection):
                         if stripped in already:
                             found = True
                     if found is not True:
-                        replacable = pattern.sub(pair[2]+" ", replacable)
+                        replacable = pattern.sub(pair[2], replacable)
                         alreadys.append(pair[2])
 
             except Exception as excep:


### PR DESCRIPTION
If the denormalize tag is used in the aiml, y-bot is not able to denormalize the string as it matches only against lower case pattern but all the inputs are converted to uppercase before it starts matching. Also the extra space is not required in case of denormalization.