### PR TITLE
Fix y-bot_rest.sh 500 error when trying first GET request.

### DIFF
--- a/src/programy/clients/rest.py
+++ b/src/programy/clients/rest.py
@@ -106,9 +106,10 @@ def ask():
 
 if __name__ == '__main__':
 
+    rest_client = RestBotClient()
+
     def run():
         print("Loading, please wait...")
-        rest_client = RestBotClient()
 
         print("REST Client running on %s:%s" % (rest_client.configuration.client_configuration.host,
                                                 rest_client.configuration.client_configuration.port))


### PR DESCRIPTION
Hello, I'm not too good at Python nor even Github, but I love to copy/past things and I was very happy when I found your program-y project. Indeed after looking around on many complicated "buy" solutions for bots, I consider AIML v2 as a real evolutive alternative. I hope I will be able to contribute from a way or an other.

Here is my first contribution.
As I would not say that I'm a python expert, I have to admit that I'm not sure this fix is the proper approach. But at least it fix y-bot_rest.sh 500 error I have when trying to GET an answer on default config for the first time.

_Note: may be I need to add that I have installed and tried the config on Python 3.6_

Hope this can help.
Olivier from Paris.