### PR TITLE
Proposal for customising webchat template including initial_question

### DIFF
--- a/src/programy/clients/webchat/chatsrv.py
+++ b/src/programy/clients/webchat/chatsrv.py
@@ -8,6 +8,8 @@ from flask import abort
 from flask import current_app
 from programy.clients.client import BotClient
 from programy.config.sections.client.webchat import WebChatConfiguration
+from templateprocessing import process_htmltemplate
+import os
 
 class WebChatBotClient(BotClient):
 
@@ -28,7 +30,9 @@ APP = Flask(__name__)
 
 @APP.route('/')
 def index():
-    return current_app.send_static_file('webchat.html')
+    url = os.path.join(current_app.root_path, current_app.static_folder, 'webchat.html')
+    return process_htmltemplate(url)
+
 
 # Enter you API keys, here, alternatively store in a db or file and load at startup
 # This is an exmaple, and therefore not suitable for production

--- a/src/programy/clients/webchat/static/webchat.html
+++ b/src/programy/clients/webchat/static/webchat.html
@@ -36,7 +36,10 @@
                     <div style="clear:both"></div>
                 </div>
 
-                <div id="chatbox"></div>
+                <div id="chatbox">
+                    <p><b>Bot:</b>$initial_question</p>
+                    <p><hr /></p>
+                </div>
 
                 <form name="message" action="">
                     <input name="usermsg" type="text" id="usermsg" size="63" />

--- a/src/programy/clients/webchat/static/y-bot.js
+++ b/src/programy/clients/webchat/static/y-bot.js
@@ -1,9 +1,6 @@
 // jQuery Document
 $(document).ready(function(){
 
-    $("#chatbox").append ("<p><b>Bot:</b>Hello, my name is Y-Bot, how can I help you today?</p>" );
-    $("#chatbox").append ("<p><hr /></p>" );
-
     $(".question").click(function() {
 
         var question = $(this).text()

--- a/src/programy/clients/webchat/templateprocessing.py
+++ b/src/programy/clients/webchat/templateprocessing.py
@@ -1,0 +1,56 @@
+###############################################################################
+#   Process webchat.html for custom variables and replace it before render
+#   So far only $initial_question variable is used in webchat.html but
+#   more variables coube be used from confg.yaml in webchat section for instance
+#   such variable could be something like:
+#   webchat:
+#     host: 0.0.0.0
+#     port: 8080
+#     debug: false
+#     head_title: "Program-Y webchat demo"
+#     header: |
+#       <h1>Welcome to Program-Y Demonstration</h1>
+#       <h3>A Fully 2.x AIML Complaint Python 3 based Open Source Chatbot Framework</h3>
+#     footer: |
+#       <a href="https://github.com/keiffster/program-y">Program-Y on GitHub</a> |
+#       <a href="https://github.com/keiffster/program-y/wiki">Documentation</a> |
+#       <a href="http://www.keithsterling.com">Meet the Author</a> |
+#       <a href="http://servusai.com">Professional Services</a>
+#     popular_questions: |
+#    	  <p class="welcome">Popular Questions<b></b></p>
+#       <ul>
+#         <li class="question"><a href="#">Who are you?</a></li>
+#         <li class="question"><a href="#">What are you?</a></li>
+#         <li class="question"><a href="#">Where are you?</a></li>
+#       </ul>       
+###############################################################################
+
+from programy.config.sections.bot.bot import BotConfiguration
+from programy.config.sections.client.console import ConsoleConfiguration
+from programy.config.file.yaml_file import YamlConfigurationFile
+
+def process_htmltemplate(url):
+  #############################################################################
+  # TODO: 
+  #   get bot configuration here from config.yaml
+  #   and replace bellow temporary settings
+  #############################################################################
+
+  yaml = YamlConfigurationFile()
+  
+  yaml.load_from_text("""
+  bot:
+    initial_question: Hello, how do you like your custom initial_question ?
+  """, ConsoleConfiguration(), ".")
+  bot_config = BotConfiguration()
+  bot_config.load_configuration(yaml, ".")
+
+  with open(url, 'r') as file :
+    filedata = file.read()
+  filedata = filedata.replace('$initial_question', bot_config.initial_question)
+  # proposition for other custom webchat sttings that could be set
+  #filedata = filedata.replace('$head_title', webchat_config.head_title)
+  #filedata = filedata.replace('$header', webchat_config.header)
+  #filedata = filedata.replace('$popular_questions', webchat_config.popular_questions)
+  #filedata = filedata.replace('$footer', webchat_config.footer)
+  return filedata


### PR DESCRIPTION
This change request is an attempt to answer [#114](https://github.com/keiffster/program-y/issues/114) closed issue. I was thinking that may be case like for [Vishal-7](https://github.com/Vishal-7) having a customisation of it's webchat page would bring complication for program-y core update from git.
This Change Request is incomplete as set custom _initial_question_ taken from hardcoded yaml.load_from_text in stead of loading from real config.yaml file. So if you think this could be an acceptable change request, you would need to change this and take _initial_question_ from config.yaml.
Sorry: I'm not that good in Python and I couldn't get how your read from the config.taml file ;( And I miss time to go further.
In addition, I have commented in the templateprocessing.py source about possible other customisable items in webchat.html (head_title, header, footer and popular_questions). In other words, if this make sens to you to add such level of customisation on the way of _initial_question_, you will then have to set this new parameters in config.yaml structure + add your testing soup (which is also still a bit hard for me to have a clear understanding on how the all thing work - I still have a lot to learn in Python).

Please, note that if this is too messy code (I know I'm a messy coder ;)) I will not be offended at all if this change request is not approved (anyway it's need some few code addition to be fully operational).

O.