### PR TITLE
Change discord dependency to discord.py

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,7 @@ slackclient==1.3.1
 viberbot==1.0.11
 line-bot-sdk==1.8.0
 kik==1.5.0
-discord==1.0.1
+discord.py==1.0.1
 botbuilder-core==4.0.0a6
 botbuilder-schema==4.0.0a6
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ slackclient==1.3.1
 viberbot==1.0.11
 line-bot-sdk==1.8.0
 kik==1.5.0
-discord==1.0.1
+discord.py==1.0.1
 botbuilder-core==4.0.0a6
 botbuilder-schema==4.0.0a6
 

--- a/src/setup.py
+++ b/src/setup.py
@@ -74,7 +74,7 @@ setup(
     'line-bot-sdk==1.8.0',
     'kik==1.5.0',
     'wikipedia==1.4.0',
-    'discord==1.0.1',
+    'discord.py==1.0.1',
     'botbuilder-core==4.0.0a6',
     'botbuilder-schema==4.0.0a6',
     'MetOffer==1.3.2',


### PR DESCRIPTION
`discord` is simply a mirror/wrapper package for `discord.py`.
There's no need to install `discord.py` indirectly through another package.