### PR TITLE
Fix missing comma in setup

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -80,7 +80,7 @@ setup(
     'MetOffer==1.3.2',
     'APScheduler==3.6.0',
     'emoji==0.5.2',
-    'textblob==0.15.3'
+    'textblob==0.15.3',
     'autocorrect==0.3.0',
     'redis==3.2.1',
     'pymongo==3.8.0',


### PR DESCRIPTION
3.8.2 currently errors with:
```
Collecting textblob==0.15.3autocorrect==0.3.0 (from programy)
  ERROR: Could not find a version that satisfies the requirement textblob==0.15.3autocorrect==0.3.0 (from programy) (from versions: . . . )
ERROR: No matching distribution found for textblob==0.15.3autocorrect==0.3.0 (from programy)`
```