### PR TITLE
Differenciate v1/v2 flask response format

### DIFF
--- a/src/programy/clients/restful/flask/client.py
+++ b/src/programy/clients/restful/flask/client.py
@@ -28,11 +28,13 @@ class FlaskRestBotClient(RestBotClient):
     def server_abort(self, error_code):
         abort(error_code)
 
-    def create_response(self, response_data, status):
+    def create_response(self, response_data, status, version):
         if self.configuration.client_configuration.debug is True:
             self.dump_request(response_data)
-
-        return make_response(jsonify(response_data, status))
+        if version < 2.0:
+            return make_response(jsonify(response_data, status))
+        else:
+            return make_response(jsonify(response_data))    
 
     def run(self, flask):
 
@@ -73,12 +75,12 @@ if __name__ == '__main__':
     @APP.route('/api/rest/v1.0/ask', methods=['GET', 'POST'])
     def ask_v1_0():
         response_data, status = REST_CLIENT.process_v1_0_request(request)
-        return REST_CLIENT.create_response(response_data, status)
+        return REST_CLIENT.create_response(response_data, status, version=1.0)
 
     @APP.route('/api/rest/v2.0/ask', methods=['GET', 'POST'])
     def ask_v2_0():
         response_data, status = REST_CLIENT.process_v2_0_request(request)
-        return REST_CLIENT.create_response(response_data, status)
+        return REST_CLIENT.create_response(response_data, status, version=2.0)
 
     print("Loading, please wait...")
     REST_CLIENT = FlaskRestBotClient("flask")


### PR DESCRIPTION
Just to point out the issue with format given by make_response when status is provided.
In stead of having:
```javascript
{ 
  "meta":
  {
    "authors":["Keith Sterling"],
    "botName":"Program-y",
    "copyright":"Copyright 2016-2019 keithsterling.com",
    "version":"1.0.0"
  },
  "response":
  {
    "query":"hello",
    "text":"Chatbot1 says hello.",
    "timestamp":1557666224.758446,
    "userId":"1234"
  },
  "status":
  {
    "code":200,
    "message":"success"}
  }
}
```

we have (from my memory): 
```javascript
[{ 
  "meta":
  {
    "authors":["Keith Sterling"],
    "botName":"Program-y",
    "copyright":"Copyright 2016-2019 keithsterling.com",
    "version":"1.0.0"
  },
  "response":
  {
    "query":"hello",
    "text":"Chatbot1 says hello.",
    "timestamp":1557666224.758446,
    "userId":"1234"
  },
  "status":
  {
    "code":200,
    "message":"success"}
  }
}, 200]
```

As stated. This PR does not absolutely need to be applied. You probably have other preferred ways to implement this.